### PR TITLE
updated blend mode when padding 0

### DIFF
--- a/lib/src/step_progress_indicator.dart
+++ b/lib/src/step_progress_indicator.dart
@@ -1,6 +1,7 @@
 library step_progress_indicator;
 
 import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 /// (Linear) Progress indicator made of a series of steps
@@ -290,11 +291,7 @@ class StepProgressIndicator extends StatelessWidget {
       return ShaderMask(
         shaderCallback: (rect) => gradient.createShader(rect),
         // Apply user defined blendMode if defined, default otherwise
-        blendMode: blendMode != null
-            ? blendMode!
-            : padding == 0
-                ? BlendMode.src
-                : BlendMode.modulate,
+        blendMode: blendMode != null ? blendMode! : BlendMode.modulate,
         child: child,
       );
     } else {


### PR DESCRIPTION
Fixes #32 

The issue occurred when `padding: 0`, `gradient` applied, and `roundedEgde` applied. It was causes by `blendMode`.

Example:
```dart
class GradientRoundedEdge extends StatelessWidget {
  const GradientRoundedEdge({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: SafeArea(
          child: Padding(
        padding: const EdgeInsets.all(50.0),
        child: Column(
          children: [
            Container(
              color: Colors.grey[600],
              padding: const EdgeInsets.all(10),
              child: const StepProgressIndicator(
                totalSteps: 100,
                currentStep: 40,
                size: 30,
                padding: 0,
                roundedEdges: Radius.circular(100),
                selectedGradientColor: LinearGradient(
                  begin: Alignment.topLeft,
                  end: Alignment.bottomRight,
                  colors: [
                    Color(0XFFFFE2CD),
                    Color(0XFFFEC2E7),
                    Color(0XFFC9E7FF),
                    Color(0XFF86FEF4),
                  ],
                ),
                unselectedGradientColor: LinearGradient(
                  begin: Alignment.topLeft,
                  end: Alignment.bottomRight,
                  colors: [
                    Color(0XFF171C21),
                    Colors.black,
                  ],
                ), // Needed
              ),
            ),
          ],
        ),
      )),
    );
  }
}
```


<img width="291" alt="Screenshot 2022-01-02 at 17 11 38" src="https://user-images.githubusercontent.com/10065056/147881864-dfcb0d6f-2f0e-4996-8a56-cda49b28f887.png">

